### PR TITLE
Added Merge All Duplicates button

### DIFF
--- a/client/components/duplicates/index.tsx
+++ b/client/components/duplicates/index.tsx
@@ -190,10 +190,21 @@ const Duplicates = () => {
         });
     }
 
+    const mergeAll = useCallback(async () => {
+        for (const pair of pairs) {
+            await dispatch(BanksStore.mergeTransactions(pair[0], pair[1]));
+        }
+    }, [dispatch, pairs]);
+
     return (
         <React.Fragment>
             <p className="right-align">
                 <DefaultParameters />
+            </p>
+            <p className="right-align">
+                <button className="btn warning" onClick={mergeAll}>
+                    <span>{$t('client.general.merge_all')}</span>
+                </button>
             </p>
 
             <div>

--- a/shared/locales/en.json
+++ b/shared/locales/en.json
@@ -215,6 +215,7 @@
             "edit": "Edit",
             "save": "Save",
             "default_parameters": "Default parameters",
+            "merge_all": "Merge all duplicates",
             "select": "Select…",
             "select_all": "Select all",
             "unselect_all": "Unselect all",

--- a/shared/locales/es.json
+++ b/shared/locales/es.json
@@ -191,6 +191,7 @@
       "edit": "Editar",
       "save": "Guardar",
       "default_parameters": "Ajustes por defecto",
+      "merge_all": "Fusionar todos los duplicados",
       "select": "Seleccione una…",
       "select_all": "Seleccionar todo",
       "unselect_all": "Deseleccionar todo",

--- a/shared/locales/fr.json
+++ b/shared/locales/fr.json
@@ -211,6 +211,7 @@
             "edit": "Éditer",
             "save": "Sauver",
             "default_parameters": "Paramètres par défaut",
+            "merge_all": "Fusionner tous les doublons",
             "select": "Sélectionner…",
             "select_all": "Sélectionner tout",
             "unselect_all": "Désélectionner tout",

--- a/shared/locales/tr.json
+++ b/shared/locales/tr.json
@@ -191,6 +191,7 @@
             "edit": "Düzenle",
             "save": "Kaydet",
             "default_parameters": "Varsayılan ayarlar",
+            "merge_all": "Tüm kopyaları birleştir",
             "select": "Seç...",
             "select_all": "Hepsini seç",
             "unselect_all": "Tüm seçimleri kaldır",


### PR DESCRIPTION
The button currently calls the backend once per item on the page.

This could be improved by adding the duplicate detection to the backend.
A warning could also be displayed to the user before the merge.